### PR TITLE
Add `agent` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,22 @@ The root directory where the files will be searched for. By default, this option
 RSA key file. You must upload a public key to the remote server before attempting to upload any content.
  - `'/Users/User1/.ssh/id_rsa'`
 
- Either this option or `password` must be set.
+ Either this option, `agent` or `password` must be set.
+
+*Default:* `undefined`
+
+### agent
+
+Path to ssh-agent's UNIX socket for ssh-agent-based user authentication (when your private keys are loaded into your agent). You must upload a public key to the remote server before attempting to upload any content. Windows users: set to 'pageant' for authenticating with Pageant or (actual) path to a cygwin "UNIX socket."
+ - `process.env.SSH_AUTH_SOCK`
+
+ Either this option, `privateKey` or `password` must be set.
 
 *Default:* `undefined`
 
 ### password
 
-Password for `remoteUser`. Either this option or `privateKey` must be set.
+Password for `remoteUser`. Either this option, `agent` or `privateKey` must be set.
 
 *Default:* `undefined`
 

--- a/index.js
+++ b/index.js
@@ -32,6 +32,9 @@ module.exports = {
         privateKey: function(context) {
           return context.privateKey;
         },
+        agent: function(context) {
+          return context.agent;
+        },
         password: function(context) {
           return context.password;
         }
@@ -47,6 +50,7 @@ module.exports = {
             path: this.readConfig('distDir'),
             remoteDir: this.readConfig('remoteDir'),
             privateKey: this.readConfig('privateKey') && fs.readFileSync(this.readConfig('privateKey')),
+            agent: this.readConfig('agent'),
             password: this.readConfig('password')
           },
           sftp = new Sftp(options);


### PR DESCRIPTION
Add an option to use an SSH agent to provide a private key instead of specifying the private key explicitly using the `privateKey` option. This is useful is you are using encrypted private keys managed by an ssh-agent process.