### PR TITLE
Added passphase option for privateKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ RSA key file. You must upload a public key to the remote server before attemptin
 
 *Default:* `undefined`
 
+
+### passphrase
+
+For passphrase protected privateKeys.
+
+ If you pass this value `privateKey` must be set.
+
+*Default:* `undefined
+
 ### agent
 
 Path to ssh-agent's UNIX socket for ssh-agent-based user authentication (when your private keys are loaded into your agent). You must upload a public key to the remote server before attempting to upload any content. Windows users: set to 'pageant' for authenticating with Pageant or (actual) path to a cygwin "UNIX socket."

--- a/index.js
+++ b/index.js
@@ -32,6 +32,9 @@ module.exports = {
         privateKey: function(context) {
           return context.privateKey;
         },
+        passphrase: function(context) {
+          return context.passphrase;
+        },
         agent: function(context) {
           return context.agent;
         },
@@ -51,7 +54,8 @@ module.exports = {
             remoteDir: this.readConfig('remoteDir'),
             privateKey: this.readConfig('privateKey') && fs.readFileSync(this.readConfig('privateKey')),
             agent: this.readConfig('agent'),
-            password: this.readConfig('password')
+            password: this.readConfig('password'),
+            passphrase: this.readConfig('passphrase')
           },
           sftp = new Sftp(options);
 


### PR DESCRIPTION
My `privateKey` has a passphrase attached to it. This caused an issue when deploying. I have provided a new option `passphrase` to pass down to SSH2